### PR TITLE
Update jsonata import usage

### DIFF
--- a/jsonata.py
+++ b/jsonata.py
@@ -1,5 +1,5 @@
 import json
-from jsonata import jsonata
+import jsonata
 
 def transform_json_with_jsonata(json_data: dict, jsonata_expression: str) -> dict:
     """
@@ -13,8 +13,8 @@ def transform_json_with_jsonata(json_data: dict, jsonata_expression: str) -> dic
         dict: Das transformierte JSON-Objekt.
     """
     try:
-        j_expression = jsonata(jsonata_expression)
-        transformed_data = j_expression.evaluate(json_data)
+        j_expression = jsonata.jsonata(jsonata_expression)
+        transformed_data = j_expression.match(json_data)
         return transformed_data
     except Exception as e:
         print(f"Fehler bei der Transformation: {e}")


### PR DESCRIPTION
## Summary
- fix import style for `jsonata` module
- call `jsonata.jsonata` and use `.match`

## Testing
- `python -m py_compile jsonata.py`


------
https://chatgpt.com/codex/tasks/task_e_688a7c8be870832da772c63089bd7791