### PR TITLE
Add advanced JSONata transformation

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@ Diese kleine Anwendung erlaubt es, mehrere CSV-Zeilen einzufügen, die jeweils e
 1. `transform.html` in einem Browser öffnen.
 2. Die CSV-Daten in das Textfeld einfügen (inklusive mehrerer Zeilen).
 3. Auf **Transformieren** klicken.
-4. Das transformierte JSON erscheint darunter und kann kopiert werden.
+4. Darunter erscheint eine Tabelle mit dem transformierten JSON je Zeile.
+   Über den **Kopieren**-Knopf in jeder Tabellenzeile kann das jeweilige JSON in die Zwischenablage übernommen werden.
 
-Die Transformation erzeugt für jede Zeile ein JSON mit grundlegenden Informationen zum Produktionsauftrag.
+Die Transformation erzeugt für jede Zeile ein JSON mit umfangreichen Informationen zum Produktionsauftrag.

--- a/transform.html
+++ b/transform.html
@@ -6,7 +6,9 @@
 <style>
   body { font-family: Arial, sans-serif; margin: 20px; }
   textarea { width: 100%; box-sizing: border-box; }
-  #jsonOutput { height: 300px; }
+  #resultsTable { width: 100%; border-collapse: collapse; margin-top: 10px; }
+  #resultsTable th, #resultsTable td { border: 1px solid #ccc; padding: 5px; vertical-align: top; }
+  pre { margin: 0; white-space: pre-wrap; word-break: break-word; }
 </style>
 </head>
 <body>
@@ -15,17 +17,123 @@
 <textarea id="csvInput" rows="10" placeholder="CSV-Daten hier einfügen"></textarea>
 <button id="transformButton">Transformieren</button>
 <h2>Ausgabe</h2>
-<textarea id="jsonOutput" readonly></textarea>
+<table id="resultsTable">
+  <thead>
+    <tr><th>#</th><th>JSON</th><th>Aktion</th></tr>
+  </thead>
+  <tbody></tbody>
+</table>
 <script src="https://cdn.jsdelivr.net/npm/jsonata/jsonata.min.js"></script>
 <script>
 const expression = `{
-  "messageType": "GB.D365EventProcessor.D365EventTransformed.ProductionOrderWithdrawn",
+  "messageType": [
+    "GB.D365EventProcessor.D365EventTransformed.ProductionOrderReleased"
+  ],
   "timestamp": $join([FXLHeader.SystemDate, "T", FXLHeader.SystemTime, ".000Z"]),
   "productionId": ProdTable.FIELD_ProdTable_ProdId,
+  "project": ProdTable.SalesTable.FIELD_SalesTable_GLDGlobalProjId ? ProdTable.SalesTable.FIELD_SalesTable_GLDGlobalProjId : null,
   "productionStatus": ProdTable.FIELD_ProdTable_ProdStatus,
-  "productionStatusDescription": ProdTable.FIELD_ProdTable_ProdStatus1,
-  "site": ProdTable.FIELD_ProdTable_inventDim_InventSiteId,
-  "warehouse": ProdTable.FIELD_ProdTable_inventDim_InventLocationId
+  "productionSite": FXLHeader.Company,
+  "productionWarehouse": ProdTable.FIELD_ProdTable_inventDim_InventLocationId,
+  "plannedProductionQuantity": $number(ProdTable.FIELD_ProdTable_QtySched),
+  "plannedProductionStartDateTime": $join([ProdTable.FIELD_ProdTable_SchedStart, "T", ProdTable.FIELD_ProdTable_SchedFromTime, ".000Z"]),
+  "plannedProductionEndDateTime": $join([ProdTable.FIELD_ProdTable_SchedEnd, "T", ProdTable.FIELD_ProdTable_SchedToTime, ".000Z"]),
+  "partListId": ProdTable.FIELD_ProdTable_gldPartlistId,
+  "bomReference": ProdTable.FIELD_ProdTable_GLDCollectRefProdId,
+  "bomLevel": ProdTable.FIELD_ProdTable_GLDCollectRefLevel,
+  "bomListId": ProdTable.FIELD_ProdTable_BOMId,
+  "inputMaterialAvailabilityDate": ProdTable.FIELD_ProdTable_gaxDisplayAvailabilityDate,
+  "itemNumber": ProdTable.FIELD_ProdTable_ItemId,
+  "itemName": ProdTable.FIELD_ProdTable_Name,
+  "itemAbbreviation": ProdTable.InventTable.FIELD_InventTable_GLDItemAbbreviation,
+  "partGrossHeight": $number(ProdTable.FIELD_ProdTable_inventTable_grossHeight),
+  "partGrossWidth": $number(ProdTable.FIELD_ProdTable_inventTable_grossWidth),
+  "partGrossDepth": $number(ProdTable.FIELD_ProdTable_inventTable_grossDepth),
+  "partGrossWeight": $number(ProdTable.FIELD_ProdTable_inventTable_grossWeight),
+  "partGrossVolume": $number(ProdTable.FIELD_ProdTable_inventTable_grossVolume),
+  "resource": ProdTable.ProdRoute[0].ProdRouteJob[0].FIELD_ProdRouteJob_WrkCtrId,
+  "orderNumber": ProdTable.FIELD_ProdTable_GLDICSalesId ? ProdTable.FIELD_ProdTable_GLDICSalesId : null,
+  "mesColor": ProdTable.FIELD_ProdTable_GLDColor,
+  "mesCoatingType": ProdTable.FIELD_ProdTable_GLDCoatingType,
+  "rawMaterialProfile": ProdTable.FIELD_ProdTable_GLDRawMaterialProfileItemId,
+  "rawMaterialConfig": ProdTable.FIELD_ProdTable_GLDRawMaterialConfigId,
+  "rawMaterialColor": ProdTable.FIELD_ProdTable_GLDRawMaterialColor,
+  "rawMaterialStyle": ProdTable.FIELD_ProdTable_GLDRawMaterialStyleId,
+  "serialId": ProdTable.ProdTable.FIELD_ProdTable_inventDim_inventSerialId,
+  "refProductionId": ProdTable.ProdTable_GLDCollectRef.FIELD_ProdTable_ProdId,
+  "referenceOrder": {
+    "productionId": ProdTable.ProdTable_GLDCollectRef.FIELD_ProdTable_ProdId,
+    "productionStatusDescription": ProdTable.ProdTable_GLDCollectRef.FIELD_ProdTable_ProdStatus1,
+    "resourcePoolId": ProdTable.ProdTable_GLDCollectRef.FIELD_ProdTable_GLDResourcePoolId,
+    "capabilityDescription": ProdTable.ProdTable_GLDCollectRef.FIELD_ProdTable_GLDWrkCtrCapabilityDescription1,
+    "itemId": ProdTable.ProdTable_GLDCollectRef.FIELD_ProdTable_ItemId,
+    "itemName": ProdTable.ProdTable_GLDCollectRef.FIELD_ProdTable_Name,
+    "productionStatus": $number(ProdTable.ProdTable_GLDCollectRef.RefProdStatus),
+    "scheduledDate": ProdTable.ProdTable_GLDCollectRef.FIELD_ProdTable_SchedDate,
+    "scheduledTime": ProdTable.ProdTable_GLDCollectRef.FIELD_ProdTable_SchedFromTime,
+    "scheduledDateTime": (
+      $date := ProdTable.ProdTable_GLDCollectRef.FIELD_ProdTable_SchedDate;
+      $time := ProdTable.ProdTable_GLDCollectRef.FIELD_ProdTable_SchedFromTime;
+      $date and $time ? $join([$date, "T", $time, ".000Z"]) : null
+    ),
+    "deliveryDate": ProdTable.ProdTable_GLDCollectRef.FIELD_ProdTable_DlvDate
+  },
+  "successor": {
+    "productionId": ProdTable.ProdTable_RefOrder.FIELD_ProdTable_ProdId,
+    "productionStatusDescription": ProdTable.ProdTable_RefOrder.FIELD_ProdTable_ProdStatus1,
+    "capabilityDescription": ProdTable.ProdTable_RefOrder.FIELD_ProdTable_GLDWrkCtrCapabilityDescription,
+    "itemId": ProdTable.ProdTable_RefOrder.FIELD_ProdTable_ItemId,
+    "itemName": ProdTable.ProdTable_RefOrder.FIELD_ProdTable_Name,
+    "productionStatus": $number(ProdTable.ProdTable_RefOrder.RefProdStatus),
+    "scheduledDate": ProdTable.ProdTable_RefOrder.FIELD_ProdTable_SchedDate,
+    "scheduledTime": ProdTable.ProdTable_RefOrder.FIELD_ProdTable_SchedFromTime,
+    "scheduledDateTime": (
+      $date := ProdTable.ProdTable_RefOrder.FIELD_ProdTable_SchedDate;
+      $time := ProdTable.ProdTable_RefOrder.FIELD_ProdTable_SchedFromTime;
+      $date and $time ? $join([$date, "T", $time, ".000Z"]) : undefined
+    )
+  },
+  "productionRouteOperation": ProdTable.ProdRoute.ProdRouteJob[].{
+    "productionRouteJobID": FIELD_ProdRouteJob_JobId,
+    "productionRouteOperationNumber": FIELD_ProdRouteJob_OprNum,
+    "productionRouteOperationPriority": FIELD_ProdRouteJob_OprPriority,
+    "productionRouteOperation": FIELD_ProdRouteJob_prodRoute_OprId,
+    "productionRouteOperationJobType": FIELD_ProdRouteJob_JobType,
+    "productionRouteOperationName": FIELD_ProdRouteJob_prodRoute_operationName,
+    "productionRouteOperationRunTime": $number(FIELD_ProdRouteJob_prodRoute_ProcessTime),
+    "productionRouteOperationProcessQuantity": $number(FIELD_ProdRouteJob_prodRoute_ProcessPerQty),
+    "productionRouteOperationResource": FIELD_ProdRouteJob_prodRoute_displayWrkCtrId,
+    "productionRouteOperationStartDateTime": $join([FIELD_ProdRouteJob_prodRoute_FromDate, "T", FIELD_ProdRouteJob_prodRoute_FromTime, ".000Z"]),
+    "productionRouteOperationEndDateTime": $join([FIELD_ProdRouteJob_prodRoute_ToDate, "T", FIELD_ProdRouteJob_prodRoute_ToTime, ".000Z"]),
+    "productionRouteOperationTransportTime": $number(FIELD_prodRoute_TransTime),
+    "productionRouteOperationComputedEndTime": $fromMillis(
+        $toMillis($join([FIELD_ProdRouteJob_prodRoute_ToDate, "T", FIELD_ProdRouteJob_prodRoute_ToTime, ".000Z"]))
+        + ($number(FIELD_prodRoute_TransTime) * 60000)
+      )
+  },
+  "bomListLine": ProdTable.ProdBOM[].{
+    "partListLinePosition": FIELD_ProdBOM_LineNum,
+    "partItemNumber": FIELD_ProdBOM_ItemId,
+    "partOperationNumber": FIELD_ProdBOM_OprNum,
+    "partProductName": FIELD_ProdBOM_itemName,
+    "partQuantity": $number(FIELD_ProdBOM_BOMQty),
+    "partQuantityUnit": FIELD_ProdBOM_UnitId,
+    "partColor": FIELD_ProdBOM_inventDim_InventColorId,
+    "partGrossHeight": $number(FIELD_ProdBOM_inventTable_grossHeight),
+    "partGrossWidth": $number(FIELD_ProdBOM_inventTable_grossWidth),
+    "partGrossDepth": $number(FIELD_ProdBOM_inventTable_grossDepth),
+    "partGrossWeight": $number(FIELD_ProdBOM_inventTable_grossWeight),
+    "partCalculatedQuantity": $number(FIELD_ProdBOM_QtyBOMCalc),
+    "partRemainingQuantity": $number(FIELD_ProdBOM_RemainBOMPhysical),
+    "partSize": $exists(FIELD_ProdBOM_inventDim_InventSizeId) and $not(FIELD_ProdBOM_inventDim_InventSizeId in ["", ".", null]) ? $number(FIELD_ProdBOM_inventDim_InventSizeId) : undefined,
+    "partProductNumber": FIELD_ProdBOM_fxlDisplayProductNumber,
+    "partConfigId": FIELD_ProdBOM_inventDim_configId,
+    "partColorId": FIELD_ProdBOM_inventDim_InventColorId,
+    "partSizeId": FIELD_ProdBOM_inventDim_InventSizeId,
+    "partStyleId": FIELD_ProdBOM_inventDim_InventStyleId,
+    "partBatchNumber": FIELD_ProdBOM_inventDim_inventBatchId,
+    "inventTransId": FIELD_ProdBOM_InventTransId
+  }
 }`;
 
 const transform = jsonata(expression);
@@ -36,23 +144,40 @@ document.getElementById('transformButton').addEventListener('click', () => {
   if(lines.length && lines[0].startsWith('"timestamp"')) {
     lines.shift();
   }
-  const results = [];
-  for (const line of lines) {
+  const tbody = document.querySelector('#resultsTable tbody');
+  tbody.innerHTML = '';
+  lines.forEach((line, idx) => {
     const comma = line.indexOf(',');
-    if (comma === -1) continue;
+    if (comma === -1) return;
     let jsonPart = line.slice(comma + 1).trim();
     if (jsonPart.startsWith('"') && jsonPart.endsWith('"')) {
       jsonPart = jsonPart.slice(1, -1);
     }
+    let formatted;
     try {
       const message = JSON.parse(jsonPart);
       const result = transform.evaluate(message);
-      results.push(JSON.stringify(result, null, 2));
+      formatted = JSON.stringify(result, null, 2);
     } catch(e) {
-      results.push(`Fehler bei Zeile: ${line}\n${e}`);
+      formatted = `Fehler bei Zeile: ${line}\n${e}`;
     }
-  }
-  document.getElementById('jsonOutput').value = results.join('\n\n');
+    const tr = document.createElement('tr');
+    const tdIndex = document.createElement('td');
+    tdIndex.textContent = idx + 1;
+    const tdJson = document.createElement('td');
+    const pre = document.createElement('pre');
+    pre.textContent = formatted;
+    tdJson.appendChild(pre);
+    const tdAction = document.createElement('td');
+    const btn = document.createElement('button');
+    btn.textContent = 'Kopieren';
+    btn.addEventListener('click', () => navigator.clipboard.writeText(formatted));
+    tdAction.appendChild(btn);
+    tr.appendChild(tdIndex);
+    tr.appendChild(tdJson);
+    tr.appendChild(tdAction);
+    tbody.appendChild(tr);
+  });
 });
 </script>
 </body>


### PR DESCRIPTION
## Summary
- embed the full JSONata expression for production order transformation
- show transformed results in a table with a copy button
- document new workflow in README

## Testing
- `python -m py_compile jsonata.py`
- `python jsonata.py` *(fails: 'module' object is not callable')*

------
https://chatgpt.com/codex/tasks/task_e_688a8307edc4832da35ab3701fe2f635