### PR TITLE
Add CLI transformer and refactor

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,3 +12,11 @@ Diese kleine Anwendung erlaubt es, mehrere CSV-Zeilen einzufügen, die jeweils e
    Über den **Kopieren**-Knopf in jeder Tabellenzeile kann das jeweilige JSON in die Zwischenablage übernommen werden.
 
 Die Transformation erzeugt für jede Zeile ein JSON mit umfangreichen Informationen zum Produktionsauftrag.
+
+Alternativ kann die Transformation auch auf der Kommandozeile erfolgen:
+
+```
+cat eingabe.csv | python csv_transform.py
+```
+
+Dabei wird für jede Zeile der CSV-Datei das JSON transformiert und als Liste von Objekten ausgegeben.

--- a/csv_transform.py
+++ b/csv_transform.py
@@ -1,0 +1,41 @@
+import csv
+import json
+import sys
+from transformer import transform_json_with_jsonata, JSONATA_EXPRESSION
+
+def transform_csv_lines(lines):
+    reader = csv.reader(lines)
+    header = next(reader, None)
+    message_index = 1
+    if header and 'message' in [h.lower() for h in header]:
+        message_index = [h.lower() for h in header].index('message')
+    else:
+        # include header back as data row if not recognized
+        if header:
+            lines = [','.join(header)] + list(lines)
+            reader = csv.reader(lines)
+    results = []
+    for row in reader:
+        if len(row) <= message_index:
+            continue
+        json_part = row[message_index].strip()
+        if json_part.startswith('"') and json_part.endswith('"'):
+            json_part = json_part[1:-1]
+        json_part = json_part.replace('""', '"')
+        try:
+            data = json.loads(json_part)
+        except json.JSONDecodeError as e:
+            results.append({'error': str(e), 'row': row})
+            continue
+        transformed = transform_json_with_jsonata(data)
+        results.append(transformed)
+    return results
+
+def main():
+    input_text = sys.stdin.read()
+    lines = [line for line in input_text.splitlines() if line.strip()]
+    results = transform_csv_lines(lines)
+    print(json.dumps(results, indent=2, ensure_ascii=False))
+
+if __name__ == '__main__':
+    main()

--- a/transformer.py
+++ b/transformer.py
@@ -1,31 +1,11 @@
 import json
-import jsonata
+try:
+    import jsonata
+except ModuleNotFoundError:  # pragma: no cover - jsonata might be missing
+    jsonata = None
 
-def transform_json_with_jsonata(json_data: dict, jsonata_expression: str) -> dict:
-    """
-    Transformiert ein JSON-Objekt mithilfe einer JSONata-Expression.
-
-    Args:
-        json_data (dict): Das einzugebende JSON-Objekt.
-        jsonata_expression (str): Die JSONata-Expression als String.
-
-    Returns:
-        dict: Das transformierte JSON-Objekt.
-    """
-    try:
-        j_expression = jsonata.jsonata(jsonata_expression)
-        transformed_data = j_expression.match(json_data)
-        return transformed_data
-    except Exception as e:
-        print(f"Fehler bei der Transformation: {e}")
-        return {}
-
-def main():
-    """
-    Hauptfunktion zum Abfragen von Benutzereingaben und zur Durchführung der Transformation.
-    """
-    # Ihre vordefinierte JSONata-Expression
-    jsonata_expression = r'''
+# Zentrale JSONata-Expression, die von allen Funktionen verwendet wird
+JSONATA_EXPRESSION = r'''
 {
   "messageType": [
     "GB.D365EventProcessor.D365EventTransformed.ProductionOrderReleased"
@@ -137,6 +117,33 @@ def main():
   }
 }
 '''
+
+def transform_json_with_jsonata(json_data: dict, jsonata_expression: str = JSONATA_EXPRESSION) -> dict:
+    """
+    Transformiert ein JSON-Objekt mithilfe einer JSONata-Expression.
+
+    Args:
+        json_data (dict): Das einzugebende JSON-Objekt.
+        jsonata_expression (str): Die JSONata-Expression als String.
+
+    Returns:
+        dict: Das transformierte JSON-Objekt.
+    """
+    if jsonata is None:
+        raise RuntimeError("jsonata library not installed")
+    try:
+        j_expression = jsonata.jsonata(jsonata_expression)
+        transformed_data = j_expression.match(json_data)
+        return transformed_data
+    except Exception as e:
+        print(f"Fehler bei der Transformation: {e}")
+        return {}
+
+def main():
+    """
+    Hauptfunktion zum Abfragen von Benutzereingaben und zur Durchführung der Transformation.
+    """
+    jsonata_expression = JSONATA_EXPRESSION
 
     print("Bitte fügen Sie den JSON-Text ein (Beenden mit einer leeren Zeile und dann Strg+D auf Linux/macOS oder Strg+Z, Enter auf Windows):")
     json_lines = []


### PR DESCRIPTION
## Summary
- rename `jsonata.py` to `transformer.py`
- expose JSONata expression as constant and handle missing jsonata lib
- add `csv_transform.py` CLI utility
- document CLI usage in README

## Testing
- `python3 -m py_compile transformer.py csv_transform.py`

------
https://chatgpt.com/codex/tasks/task_e_688a899543fc832d9d58ae6994027a8c