### PR TITLE
Add CSV upload functionality to frontend

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+node_modules/
+output.json
+package-lock.json

--- a/README.md
+++ b/README.md
@@ -6,9 +6,10 @@ Diese kleine Anwendung erlaubt es, mehrere CSV-Zeilen einzufügen, die jeweils e
 ## Verwendung
 
 1. `transform.html` in einem Browser öffnen.
-2. Die CSV-Daten in das Textfeld einfügen (inklusive mehrerer Zeilen).
-3. Auf **Transformieren** klicken.
-4. Darunter erscheint eine Tabelle mit dem transformierten JSON je Zeile.
+2. Optional kann über **Datei auswählen** eine CSV-Datei hochgeladen werden und der Inhalt landet im Textfeld.
+3. Die CSV-Daten im Textfeld können weiterhin bearbeitet werden.
+4. Auf **Transformieren** klicken oder direkt nach dem Upload wird die Tabelle befüllt.
+5. Darunter erscheint eine Tabelle mit dem transformierten JSON je Zeile.
    Über den **Kopieren**-Knopf in jeder Tabellenzeile kann das jeweilige JSON in die Zwischenablage übernommen werden.
 
 Die Transformation erzeugt für jede Zeile ein JSON mit umfangreichen Informationen zum Produktionsauftrag.

--- a/transform.html
+++ b/transform.html
@@ -17,7 +17,9 @@
 
 <div class="max-w-7xl mx-auto">
   <h1 class="text-3xl font-bold mb-2">CSV zu JSON Transformation</h1>
-  <p class="mb-6 text-gray-600">Fügen Sie unten die CSV-Zeilen ein. Jeder Datensatz wird automatisch anhand der hinterlegten JSONata-Regel transformiert.</p>
+  <p class="mb-6 text-gray-600">Fügen Sie unten die CSV-Zeilen ein oder laden Sie eine CSV-Datei hoch. Jeder Datensatz wird automatisch anhand der hinterlegten JSONata-Regel transformiert.</p>
+
+  <input type="file" id="csvFile" accept=".csv" class="mb-4" />
 
   <textarea id="csvInput" rows="12" class="w-full p-3 border border-gray-300 rounded-md shadow-sm focus:ring-blue-500 focus:border-blue-500 mb-4" placeholder="CSV-Daten hier einfügen..."></textarea>
   <button id="transformButton" class="w-full sm:w-auto px-6 py-3 bg-blue-600 text-white font-semibold rounded-md shadow-md hover:bg-blue-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-blue-500 mb-8">Transformieren</button>
@@ -154,12 +156,11 @@ const expression = `{
 
 const transform = jsonata(expression);
 
-document.getElementById('transformButton').addEventListener('click', () => {
-  const inputText = document.getElementById('csvInput').value;
+function processCsv(text) {
   const tbody = document.querySelector('#resultsTable tbody');
   tbody.innerHTML = '';
 
-  const rawLines = inputText.trim().split(/\r?\n/);
+  const rawLines = text.trim().split(/\r?\n/);
   const logicalLines = [];
   let currentLogicalLine = "";
 
@@ -237,6 +238,23 @@ document.getElementById('transformButton').addEventListener('click', () => {
     tr.appendChild(tdAction);
     tbody.appendChild(tr);
   });
+}
+
+document.getElementById('transformButton').addEventListener('click', () => {
+  const inputText = document.getElementById('csvInput').value;
+  processCsv(inputText);
+});
+
+document.getElementById('csvFile').addEventListener('change', (e) => {
+  const file = e.target.files[0];
+  if (!file) return;
+  const reader = new FileReader();
+  reader.onload = (ev) => {
+    const text = ev.target.result;
+    document.getElementById('csvInput').value = text;
+    processCsv(text);
+  };
+  reader.readAsText(file);
 });
 </script>
 </body>


### PR DESCRIPTION
## Summary
- ignore Node artifacts
- add CSV upload support in `transform.html`
- wire JS events for upload and reuse of transformation logic
- document new workflow in README

## Testing
- `npm run transform`

------
https://chatgpt.com/codex/tasks/task_e_688a92924220832db8f7c58ac0f757f2