### PR TITLE
Add start script and README instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,3 +22,14 @@ npm run transform
 ```
 
 Der Befehl liest `test.csv`, wandelt jede Zeile per JSONata um und schreibt das Ergebnis nach `output.json`.
+
+## Website im Codespace starten
+
+Im GitHub Codespace kann ein kleiner Webserver gestartet werden, um die HTML-Oberfläche zu nutzen:
+
+```bash
+npm install    # falls noch nicht geschehen
+npm start
+```
+
+Nach dem Start zeigt Codespaces einen Link für Port 8080 an. Über diesen kann `transform.html` im Browser geöffnet werden.

--- a/package.json
+++ b/package.json
@@ -4,7 +4,8 @@
   "description": "CSV to JSON transformation using JSONata",
   "main": "csv_transform.js",
   "scripts": {
-    "transform": "node csv_transform.js test.csv > output.json"
+    "transform": "node csv_transform.js test.csv > output.json",
+    "start": "node server.js"
   },
   "dependencies": {
     "jsonata": "^1.8.6"

--- a/server.js
+++ b/server.js
@@ -1,0 +1,41 @@
+const http = require('http');
+const fs = require('fs');
+const path = require('path');
+
+const port = process.env.PORT || 8080;
+
+const mimeTypes = {
+  '.html': 'text/html',
+  '.js': 'text/javascript',
+  '.css': 'text/css',
+  '.json': 'application/json',
+  '.png': 'image/png',
+  '.jpg': 'image/jpeg',
+  '.gif': 'image/gif',
+  '.svg': 'image/svg+xml'
+};
+
+const server = http.createServer((req, res) => {
+  let filePath = '.' + (req.url === '/' ? '/transform.html' : req.url);
+  const ext = path.extname(filePath).toLowerCase();
+  const contentType = mimeTypes[ext] || 'application/octet-stream';
+
+  fs.readFile(filePath, (err, content) => {
+    if (err) {
+      if (err.code === 'ENOENT') {
+        res.writeHead(404, { 'Content-Type': 'text/plain' });
+        res.end('Not Found');
+      } else {
+        res.writeHead(500);
+        res.end('Server Error');
+      }
+    } else {
+      res.writeHead(200, { 'Content-Type': contentType });
+      res.end(content);
+    }
+  });
+});
+
+server.listen(port, () => {
+  console.log(`Server running at http://localhost:${port}/`);
+});


### PR DESCRIPTION
## Summary
- add a small Node web server so the HTML UI can be served
- expose the new `npm start` script in `package.json`
- document how to start the site when using GitHub Codespaces

## Testing
- `npm start --silent & sleep 1; pkill node`

------
https://chatgpt.com/codex/tasks/task_e_688a94b9eac8832da4b0737cc965c1a2