### PR TITLE
Improve JSON display

### DIFF
--- a/transform.html
+++ b/transform.html
@@ -15,6 +15,12 @@
     max-height: 9em;
     overflow: hidden;
   }
+  /* Farben für die Syntaxhervorhebung des JSON */
+  pre.syntax-highlight .key { color: #0451a5; }
+  pre.syntax-highlight .string { color: #a31515; }
+  pre.syntax-highlight .number { color: #098658; }
+  pre.syntax-highlight .boolean { color: #0000ff; }
+  pre.syntax-highlight .null { color: #008080; }
 </style>
 </head>
 <body class="p-6 font-sans bg-gray-50 text-gray-800">
@@ -160,6 +166,25 @@ const expression = `{
 
 const transform = jsonata(expression);
 
+// Wandelt einen JSON-String in HTML mit einfachen Farben um
+function syntaxHighlight(json) {
+  json = json
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;');
+  return json.replace(/("(\\u[\da-fA-F]{4}|\\[^u]|[^\\"])*"(:)?|\b(true|false|null)\b|-?\d+(?:\.\d*)?(?:[eE][+-]?\d+)?)/g, match => {
+    let cls = 'number';
+    if (/^"/.test(match)) {
+      cls = /:$/.test(match) ? 'key' : 'string';
+    } else if (/true|false/.test(match)) {
+      cls = 'boolean';
+    } else if (/null/.test(match)) {
+      cls = 'null';
+    }
+    return `<span class="${cls}">${match}</span>`;
+  });
+}
+
 function processCsv(text) {
   const tbody = document.querySelector('#resultsTable tbody');
   tbody.innerHTML = '';
@@ -222,8 +247,8 @@ function processCsv(text) {
     toggle.textContent = '▶';
 
     const pre = document.createElement('pre');
-    pre.className = 'text-sm text-gray-700 collapsed';
-    pre.textContent = formatted;
+    pre.className = 'text-sm text-gray-700 collapsed syntax-highlight';
+    pre.innerHTML = syntaxHighlight(formatted);
 
     toggle.addEventListener('click', () => {
       pre.classList.toggle('collapsed');


### PR DESCRIPTION
## Summary
- add a tiny syntax highlighter for JSON output
- colorize JSON display in the results table

## Testing
- `npm run transform`

------
https://chatgpt.com/codex/tasks/task_e_688af4a5a220832da0259d02a714a39f