### PR TITLE
Fix resource parsing

### DIFF
--- a/csv_transform.js
+++ b/csv_transform.js
@@ -27,7 +27,7 @@ const expression = `{
   "partGrossDepth": $number(ProdTable.FIELD_ProdTable_inventTable_grossDepth),
   "partGrossWeight": $number(ProdTable.FIELD_ProdTable_inventTable_grossWeight),
   "partGrossVolume": $number(ProdTable.FIELD_ProdTable_inventTable_grossVolume),
-  "resource": ProdTable.ProdRoute.ProdRouteJob[0].FIELD_ProdRouteJob_WrkCtrId,
+  "resource": $trim($split(ProdTable.ProdRoute.ProdRouteJob[0].FIELD_ProdRouteJob_WrkCtrId, ",")[0]),
   "orderNumber": ProdTable.FIELD_ProdTable_GLDICSalesId ? ProdTable.FIELD_ProdTable_GLDICSalesId : null,
   "mesColor": ProdTable.FIELD_ProdTable_GLDColor,
   "mesCoatingType": ProdTable.FIELD_ProdTable_GLDCoatingType,

--- a/transform.html
+++ b/transform.html
@@ -89,7 +89,7 @@ const expression = `{
   "partGrossDepth": $number(ProdTable.FIELD_ProdTable_inventTable_grossDepth),
   "partGrossWeight": $number(ProdTable.FIELD_ProdTable_inventTable_grossWeight),
   "partGrossVolume": $number(ProdTable.FIELD_ProdTable_inventTable_grossVolume),
-  "resource": ProdTable.ProdRoute.ProdRouteJob[0].FIELD_ProdRouteJob_WrkCtrId,
+  "resource": $trim($split(ProdTable.ProdRoute.ProdRouteJob[0].FIELD_ProdRouteJob_WrkCtrId, ",")[0]),
   "orderNumber": ProdTable.FIELD_ProdTable_GLDICSalesId ? ProdTable.FIELD_ProdTable_GLDICSalesId : null,
   "mesColor": ProdTable.FIELD_ProdTable_GLDColor,
   "mesCoatingType": ProdTable.FIELD_ProdTable_GLDCoatingType,


### PR DESCRIPTION
## Summary
- trim resource to only take first value when multiple are separated by comma

## Testing
- `node csv_transform.js test.csv > output.json`
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_688b0ed21a50832d8cb025abeecd85d9