### PR TITLE
Enable tag-style input for multiple product IDs

### DIFF
--- a/static/index.html
+++ b/static/index.html
@@ -74,6 +74,34 @@
             color: var(--text-tertiary);
         }
 
+        /* Tag Input Styling */
+        .tag-input-container {
+            display: flex;
+            flex-wrap: wrap;
+            gap: 0.25rem;
+        }
+
+        .tag-input-container input {
+            min-width: 8rem;
+        }
+
+        .tag-item {
+            background-color: var(--accent-primary);
+            color: white;
+            padding: 0.25rem 0.5rem;
+            border-radius: 0.375rem;
+            display: inline-flex;
+            align-items: center;
+        }
+
+        .tag-item button {
+            margin-left: 0.25rem;
+            background: none;
+            border: none;
+            cursor: pointer;
+            color: inherit;
+        }
+
         /* Button Styling */
         .btn-primary {
             background-color: var(--accent-primary);
@@ -367,8 +395,11 @@
                 </h2>
                 <div class="space-y-5">
                     <div>
-                        <label for="productIds" class="block text-sm font-medium mb-2" style="color: var(--text-secondary)">Produkt IDs</label>
-                        <textarea id="productIds" rows="3" class="input-style p-3 block w-full rounded-lg shadow-sm" placeholder="Mehrere IDs mit Komma oder Zeilenumbruch trennen">BLVSC3</textarea>
+                        <label for="productIdsInput" class="block text-sm font-medium mb-2" style="color: var(--text-secondary)">Produkt IDs</label>
+                        <div id="productIdsContainer" class="tag-input-container input-style p-2 block w-full rounded-lg shadow-sm">
+                            <input id="productIdsInput" type="text" class="tag-input bg-transparent focus:outline-none flex-grow" placeholder="ID eingeben und Enter drücken">
+                        </div>
+                        <input type="hidden" id="productIds" value="BLVSC3">
                     </div>
                     <div>
                         <label for="ConfigId" class="block text-sm font-medium mb-2" style="color: var(--text-secondary)">Variante</label>
@@ -882,7 +913,55 @@
             const closeModalButton = document.getElementById('closeModalButton');
             const copyJsonButton = document.getElementById('copyJsonButton');
             const jsonPayloadContainer = document.getElementById('jsonPayloadContainer');
-            
+
+            // Tag Input Setup for Produkt-IDs
+            const productIdsHidden = document.getElementById('productIds');
+            const productIdsInput = document.getElementById('productIdsInput');
+            const productIdsContainer = document.getElementById('productIdsContainer');
+            let productIdTags = [];
+
+            function updateProductIdsField() {
+                productIdsHidden.value = productIdTags.join(',');
+            }
+
+            function addProductTag(value) {
+                const val = value.trim();
+                if (!val || productIdTags.includes(val)) return;
+                productIdTags.push(val);
+                const tag = document.createElement('span');
+                tag.className = 'tag-item';
+                tag.textContent = val;
+                const btn = document.createElement('button');
+                btn.type = 'button';
+                btn.textContent = '×';
+                btn.addEventListener('click', () => {
+                    productIdTags = productIdTags.filter(v => v !== val);
+                    productIdsContainer.removeChild(tag);
+                    updateProductIdsField();
+                });
+                tag.appendChild(btn);
+                productIdsContainer.insertBefore(tag, productIdsInput);
+                updateProductIdsField();
+            }
+
+            productIdsInput.addEventListener('keydown', (e) => {
+                if (e.key === 'Enter' || e.key === ',') {
+                    e.preventDefault();
+                    addProductTag(productIdsInput.value);
+                    productIdsInput.value = '';
+                }
+            });
+
+            productIdsInput.addEventListener('blur', () => {
+                addProductTag(productIdsInput.value);
+                productIdsInput.value = '';
+            });
+
+            if (productIdsHidden.value) {
+                productIdsHidden.value.split(/[,\n]+/).forEach(v => addProductTag(v));
+                productIdsInput.value = '';
+            }
+
             const inputIds = ['organizationId', 'productIds', 'siteId', 'locationId', 'WMSLocationId', 'InventStatusId', 'ConfigId', 'SizeId', 'ColorId', 'StyleId', 'BatchId'];
 
             // --- Event Listeners ---


### PR DESCRIPTION
## Summary
- support entering multiple product IDs via new tag input component
- add CSS for tag styling

## Testing
- `python -m py_compile backend.py`

------
https://chatgpt.com/codex/tasks/task_e_688c8279c74c832d9f8b7f1229751a49