### PR TITLE
Switch query persistence to SQLite

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,8 +27,8 @@ einem Verbindungsfehler wie `net::ERR_CONNECTION_REFUSED` im Browser fuehrt.
 
 ## Persistenz der Abfragen
 
-Gespeicherte Abfragen werden in einer lokalen `shelve`-Datenbank (`queries.db`) abgelegt.
-Diese einfache NoSQL-Lösung benötigt keine zusätzlichen Treiber und legt die Daten im Projektverzeichnis ab.
+Gespeicherte Abfragen werden in einer lokalen SQLite-Datenbank (`queries.sqlite`) abgelegt.
+SQLite benötigt keine zusätzliche Serverinstallation und legt die Daten direkt im Projektverzeichnis ab.
 
 ## Benötigte Umgebungsvariablen
 


### PR DESCRIPTION
## Summary
- Replace shelve-based storage with SQLite database and initialization
- Update load/save helpers to operate on SQLite
- Refresh documentation to mention SQLite persistence

## Testing
- `python -m py_compile backend.py`
- `pip install fastapi -q` *(fails: Could not find a version that satisfies the requirement fastapi)*

------
https://chatgpt.com/codex/tasks/task_e_688e17106e1c832d904db057d73e72d1